### PR TITLE
Update metadata-server

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "metadata-server",
-        "rev": "4347d46f656db40057be877a1d11c7536f4f53f9",
-        "sha256": "0m2nydkdi714i0fca7f470zk4370fm7dm0p6y6wq5mqv99bvx3mb",
+        "rev": "fc26bd04600ad4c0ab4303caefce64b35857595f",
+        "sha256": "0v370anb4kmyvpp503mn5k2sqajkryi8nkahz6wvvwz5bfkzvy9v",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/metadata-server/archive/4347d46f656db40057be877a1d11c7536f4f53f9.tar.gz",
+        "url": "https://github.com/input-output-hk/metadata-server/archive/fc26bd04600ad4c0ab4303caefce64b35857595f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {


### PR DESCRIPTION
- Update metadata-server to get the following changes:
  - Increase the maximum length of subjects to 256.
  - Add tests to check the length of subjects.
  - Increase minimum number of decimals required to 1.
  - Subject previously allowed only hex digits, now it allows any
    printable Unicode character.