### PR TITLE
Update RealFi preprod token tickers

### DIFF
--- a/registry/0684f582b8abeb4236b20688744eca788a61cd9881422a7113637f6b55534472.json
+++ b/registry/0684f582b8abeb4236b20688744eca788a61cd9881422a7113637f6b55534472.json
@@ -6,8 +6,8 @@
     "signatures": []
   },
   "ticker": {
-    "sequenceNumber": 0,
-    "value": "USDR",
+    "sequenceNumber": 1,
+    "value": "USDr",
     "signatures": []
   },
   "decimals": {

--- a/registry/0684f582b8abeb4236b20688744eca788a61cd9881422a7113637f6b7355534472.json
+++ b/registry/0684f582b8abeb4236b20688744eca788a61cd9881422a7113637f6b7355534472.json
@@ -6,8 +6,8 @@
     "signatures": []
   },
   "ticker": {
-    "sequenceNumber": 0,
-    "value": "SUSDR",
+    "sequenceNumber": 1,
+    "value": "sUSDr",
     "signatures": []
   },
   "decimals": {


### PR DESCRIPTION
## Summary
- Update the RealFi preprod USDr ticker from `USDR` to `USDr`
- Update the RealFi preprod sUSDr ticker from `SUSDR` to `sUSDr`
- Increment the ticker `sequenceNumber` for both updated fields

## Network verification
- The edited subjects use policy `0684f582b8abeb4236b20688744eca788a61cd9881422a7113637f6b`.
- In the RealFi repo, `backend/config/env/preprod.protocol.yaml` maps that policy to the preprod `base/mint_proxy.mint_proxy.mint` validator.
- `backend/config/env/preview.protocol.yaml` uses policy `45df5f274b8950b512b08d10656864958659c4ecf3ffad092ef63024` for preview, so these entries are preprod, not preview.

## Validation
- Ran `jq empty` on both updated registry JSON files.